### PR TITLE
feat: add unitary tests to HomeData model

### DIFF
--- a/solutions/devsprint-vinicius-carvalho-2/FinanceApp.xcodeproj/project.pbxproj
+++ b/solutions/devsprint-vinicius-carvalho-2/FinanceApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0654F13C27FCC5D800988E6C /* HomeDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0654F13B27FCC5D800988E6C /* HomeDataTests.swift */; };
 		98426FAA27A6EC8700B09645 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98426FA927A6EC8700B09645 /* TabBarController.swift */; };
 		98426FAC27A6FC8000B09645 /* UserProfileHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98426FAB27A6FC8000B09645 /* UserProfileHeaderView.swift */; };
 		98584A6D277E32C30028DBEA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98584A6C277E32C30028DBEA /* AppDelegate.swift */; };
@@ -64,6 +65,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0654F13B27FCC5D800988E6C /* HomeDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDataTests.swift; sourceTree = "<group>"; };
 		98426FA927A6EC8700B09645 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		98426FAB27A6FC8000B09645 /* UserProfileHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileHeaderView.swift; sourceTree = "<group>"; };
 		98584A69277E32C30028DBEA /* FinanceApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FinanceApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -169,6 +171,7 @@
 			isa = PBXGroup;
 			children = (
 				98584A83277E32C60028DBEA /* FinanceAppTests.swift */,
+				0654F13B27FCC5D800988E6C /* HomeDataTests.swift */,
 			);
 			path = FinanceAppTests;
 			sourceTree = "<group>";
@@ -484,6 +487,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0654F13C27FCC5D800988E6C /* HomeDataTests.swift in Sources */,
 				98584A84277E32C60028DBEA /* FinanceAppTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/solutions/devsprint-vinicius-carvalho-2/FinanceAppTests/HomeDataTests.swift
+++ b/solutions/devsprint-vinicius-carvalho-2/FinanceAppTests/HomeDataTests.swift
@@ -1,0 +1,52 @@
+//
+//  HomeDataTests.swift
+//  FinanceAppTests
+//
+//  Created by Lucas Pinto on 05/04/22.
+//
+
+import XCTest
+
+@testable import FinanceApp
+
+class HomeDataTest: XCTestCase {
+    
+    var sut: Activity!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        sut = Activity(name: "Bob",
+                       price: 50.0,
+                       time: "20")
+    }
+    
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+    
+    func test_withFilledName_nameRegistration_shouldReturnValidFormat() {
+        let name:String = "Bob"
+        XCTAssertEqual(name, sut.name)
+    }
+    
+    func test_withFilledName_priceRegistration_shouldReturnValidFormat() {
+        let price:Float = 50.0
+        XCTAssertEqual(price, sut.price)
+    }
+    
+    func test_withFilledName_timeRegistration_shouldReturnValidFormat() {
+        let time:String = "20"
+        XCTAssertEqual(time, sut.time)
+    }
+    
+    func test_withFilledActivity_formattedInfoFunction_shoudlReturnNotNil() {
+        let formatted = sut.formattedInfo()
+        XCTAssertNotNil(formatted)
+    }
+    
+    func test_withFilledActivity_formattedInfoFunction_shoudlReturnValidResult() {
+        let formatted = sut.formattedInfo()
+        XCTAssertEqual(formatted, "$\(50.0) • \(20)")
+    }
+}


### PR DESCRIPTION
 
### Description:
 Add new unit testes to cover the HomeData.swift archive
 
### Checklist:

- [x] Não adiciona código duplicado
- [x] Não contém código comentado
- [x] Não contém código WIP
 
### Evidências da feature:
<img width="688" alt="Captura de Tela 2022-04-05 às 21 06 32" src="https://user-images.githubusercontent.com/37353008/161870968-caeb8124-bd59-47c5-9047-1eb2f2898581.png">
