### PR TITLE
adicionar teste unitário da função de formatação de string

### DIFF
--- a/solutions/devsprint-caio-santos-4/FinanceApp.xcodeproj/project.pbxproj
+++ b/solutions/devsprint-caio-santos-4/FinanceApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5EF6C6E6284E9A7700B43B57 /* HomeDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF6C6E5284E9A7700B43B57 /* HomeDataTests.swift */; };
 		98426FAA27A6EC8700B09645 /* TabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98426FA927A6EC8700B09645 /* TabBarController.swift */; };
 		98426FAC27A6FC8000B09645 /* UserProfileHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98426FAB27A6FC8000B09645 /* UserProfileHeaderView.swift */; };
 		98584A6D277E32C30028DBEA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98584A6C277E32C30028DBEA /* AppDelegate.swift */; };
@@ -66,6 +67,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5EF6C6E5284E9A7700B43B57 /* HomeDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeDataTests.swift; sourceTree = "<group>"; };
 		98426FA927A6EC8700B09645 /* TabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarController.swift; sourceTree = "<group>"; };
 		98426FAB27A6FC8000B09645 /* UserProfileHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileHeaderView.swift; sourceTree = "<group>"; };
 		98584A69277E32C30028DBEA /* FinanceApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FinanceApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -173,6 +175,7 @@
 			isa = PBXGroup;
 			children = (
 				98584A83277E32C60028DBEA /* FinanceAppTests.swift */,
+				5EF6C6E5284E9A7700B43B57 /* HomeDataTests.swift */,
 			);
 			path = FinanceAppTests;
 			sourceTree = "<group>";
@@ -500,6 +503,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5EF6C6E6284E9A7700B43B57 /* HomeDataTests.swift in Sources */,
 				98584A84277E32C60028DBEA /* FinanceAppTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/solutions/devsprint-caio-santos-4/FinanceAppTests/HomeDataTests.swift
+++ b/solutions/devsprint-caio-santos-4/FinanceAppTests/HomeDataTests.swift
@@ -1,0 +1,28 @@
+//
+//  HomeDataTests.swift
+//  FinanceAppTests
+//
+//  Created by Isabella Bencardino on 06/06/2022.
+//
+
+import XCTest
+@testable import FinanceApp
+
+class HomeDataTests: XCTestCase {
+
+    var activity: Activity!
+
+     override func setUpWithError() throws {
+         activity = Activity(name: "", price: 100.0, time: "8:57 AM")
+     }
+
+     override func tearDownWithError() throws {}
+
+    func testFormattedInfo_isCorrect() {
+         // WHEN
+         let info = activity.formattedInfo()
+
+         // THEN
+         XCTAssertEqual(info, "$100.0 • 8:57 AM")
+     }
+}


### PR DESCRIPTION
 ### ✨ Implementa teste unitário para a função `formattedInfo()`
 
 
### Checklist:

- [x] Não adiciona código duplicado
- [x] Não contém código comentado
- [x] Não contém código WIP
 
### Evidências da feature:
<img width="699" alt="Screenshot 2022-06-06 at 22 37 19" src="https://user-images.githubusercontent.com/70963868/172253491-f88f5960-2859-4b65-80ea-9d16c94aed5b.png">
<img width="336" alt="Screenshot 2022-06-06 at 22 39 21" src="https://user-images.githubusercontent.com/70963868/172253729-4f3f41a3-a714-4896-9bf2-65593ac99c9f.png">

