### PR TITLE
✨ - Add test for Formatted Account Method

### DIFF
--- a/solutions/devsprint-caio-santos-5/FinanceApp/Resources/Info.plist
+++ b/solutions/devsprint-caio-santos-5/FinanceApp/Resources/Info.plist
@@ -20,6 +20,8 @@
 	<string>1</string>
 	<key>NSAppTransportSecurity</key>
 	<true/>
+	<key>ONLY_ACTIVE_ARCH</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/solutions/devsprint-caio-santos-5/FinanceApp/Service/Entities/UserProfile.swift
+++ b/solutions/devsprint-caio-santos-5/FinanceApp/Service/Entities/UserProfile.swift
@@ -1,14 +1,6 @@
-//
-//  UserProfile.swift
-//  FinanceApp
-//
-//  Created by Rodrigo Borges on 02/03/22.
-//
-
 import Foundation
 
 struct UserProfile: Decodable {
-
     let name: String
     let phone: String
     let email: String
@@ -17,7 +9,6 @@ struct UserProfile: Decodable {
 }
 
 struct Account: Decodable {
-
     let agency: String
     let account: String
 }

--- a/solutions/devsprint-caio-santos-5/FinanceAppTests/Service/Entities/AccountTest.swift
+++ b/solutions/devsprint-caio-santos-5/FinanceAppTests/Service/Entities/AccountTest.swift
@@ -1,58 +1,70 @@
-//
-//  FormattedAgencyTest.swift
-//  FinanceAppTests
-//
-//  Created by Bruno Vieira Souza on 07/06/22.
-//
-
 import XCTest
 @testable import FinanceApp
 
-class AccountTest: XCTestCase {
-    
-    private var sut: Account?
-    
-    override func setUpWithError() throws {
-        
-    }
-
-    override func tearDownWithError() throws {
-        sut = nil
-    }
-
-    func test_formattedAgencyTest_WhenGivenAgencyInformation_ShouldFormatCorrectly() throws {
+final class AccountTest: XCTestCase {
+    func test_formattedAgency_WhenGivenAgencyInformation_ShouldFormatCorrectly() throws {
         // GIVEN
-        sut = Account(agency: "0089", account: "123456-3")
-        let sut = try XCTUnwrap(sut, "Erro ao configurar SUT")
+        let sut = Account(agency: "0089", account: "123456-3")
         
         // WHEN
         let formatterAgency = sut.formattedAgency()
 
         // THEN
-        XCTAssertEqual(formatterAgency, "Agency: \(sut.agency)", "falha ao testar formattedAgency, informando uma agencia valida!")
+        XCTAssertEqual(formatterAgency, "Agency: \(sut.agency)")
     }
     
-//    func test_formattedAgencyTest_WhenGivenAnEmptyAgencyInformation_ShouldReturnAFormattedString() throws {
-//        // GIVEN
-//        sut = Account(agency: "", account: "123456-3")
-//        let sut = try XCTUnwrap(sut, "Erro ao configurar SUT")
-//
-//        // WHEN
-//        let formatterAgency = sut.formattedAgency()
-//            
-//        // THEN
-//        XCTAssertEqual(formatterAgency, "Agency: ", "falha ao testar formattedAgency, informando uma agencia vazia!")
-//    }
-    
-    func test_formattedAgencyTest_multipleBlanksAgencyInformation_ShouldReturnAFormattedString() throws {
+    func test_formattedAgency_WhenGivenAnEmptyAgencyInformation_ShouldReturnAFormattedString() throws {
         // GIVEN
-        sut = Account(agency: "         ", account: "123456-3")
-        let sut = try XCTUnwrap(sut, "Erro ao configurar SUT")
+        let sut = Account(agency: "", account: "123456-3")
+
+        // WHEN
+        let formatterAgency = sut.formattedAgency()
+            
+        // THEN
+        XCTAssertEqual(formatterAgency, "Agency: ")
+    }
+    
+    func test_formattedAgency_multipleBlanksAgencyInformation_ShouldReturnAFormattedString() throws {
+        // GIVEN
+        let sut = Account(agency: "         ", account: "123456-3")
 
         // WHEN
         let formatterAgency = sut.formattedAgency()
         
         // THEN
-        XCTAssertEqual(formatterAgency, "Agency:          ", "falha ao testar formattedAgency, informando uma agencia com varios espaços em branco!")
+        XCTAssertEqual(formatterAgency, "Agency:          ")
+    }
+    
+    func test_formattedAccount_WhenGivenAgencyInformation_ShouldFormatCorrectly() throws {
+        // GIVEN
+        let sut = Account(agency: "dummy", account: "123456-3")
+        
+        // WHEN
+        let formatterAgency = sut.formattedAccount()
+        
+        // THEN
+        XCTAssertEqual(formatterAgency, "Account: 123456-3")
+    }
+    
+    func test_formattedAccount_WhenGivenAnEmptyAgencyInformation_ShouldReturnAFormattedString() throws {
+        // GIVEN
+        let sut = Account(agency: "dummy", account: "")
+        
+        // WHEN
+        let formatterAgency = sut.formattedAccount()
+        
+        // THEN
+        XCTAssertEqual(formatterAgency, "Account: ")
+    }
+    
+    func test_formattedAccount_multipleBlanksAgencyInformation_ShouldReturnAFormattedString() throws {
+        // GIVEN
+        let sut = Account(agency: "dummy", account: "         ")
+        
+        // WHEN
+        let formatterAgency = sut.formattedAccount()
+        
+        // THEN
+        XCTAssertEqual(formatterAgency, ("Account:          ")
     }
 }

--- a/solutions/devsprint-caio-santos-5/FinanceAppTests/Service/Entities/AccountTest.swift
+++ b/solutions/devsprint-caio-santos-5/FinanceAppTests/Service/Entities/AccountTest.swift
@@ -35,7 +35,7 @@ final class AccountTest: XCTestCase {
         XCTAssertEqual(formatterAgency, "Agency:          ")
     }
     
-    func test_formattedAccount_WhenGivenAgencyInformation_ShouldFormatCorrectly() throws {
+    func test_formattedAccount_WhenGivenAccountInformation_ShouldFormatCorrectly() throws {
         // GIVEN
         let sut = Account(agency: "dummy", account: "123456-3")
         
@@ -46,7 +46,7 @@ final class AccountTest: XCTestCase {
         XCTAssertEqual(formatterAgency, "Account: 123456-3")
     }
     
-    func test_formattedAccount_WhenGivenAnEmptyAgencyInformation_ShouldReturnAFormattedString() throws {
+    func test_formattedAccount_WhenGivenAnEmptyAccountInformation_ShouldReturnAFormattedString() throws {
         // GIVEN
         let sut = Account(agency: "dummy", account: "")
         
@@ -57,7 +57,7 @@ final class AccountTest: XCTestCase {
         XCTAssertEqual(formatterAgency, "Account: ")
     }
     
-    func test_formattedAccount_multipleBlanksAgencyInformation_ShouldReturnAFormattedString() throws {
+    func test_formattedAccount_multipleBlanksAccountInformation_ShouldReturnAFormattedString() throws {
         // GIVEN
         let sut = Account(agency: "dummy", account: "         ")
         
@@ -65,6 +65,6 @@ final class AccountTest: XCTestCase {
         let formatterAgency = sut.formattedAccount()
         
         // THEN
-        XCTAssertEqual(formatterAgency, ("Account:          ")
+        XCTAssertEqual(formatterAgency, "Account:          ")
     }
 }

--- a/solutions/devsprint-caio-santos-5/project.yml
+++ b/solutions/devsprint-caio-santos-5/project.yml
@@ -2,8 +2,8 @@ name: FinanceApp
 options:
   bundleIdPrefix: com.devpass
   deploymentTarget:
-    iOS: 15.0
-  postGenCommand: pod install
+    iOS: 15.2
+  # postGenCommand: pod install
 
 targets:
   FinanceApp:
@@ -19,6 +19,7 @@ targets:
     info:
       path: FinanceApp/Resources/Info.plist
       properties:
+        ONLY_ACTIVE_ARCH: NO
         UISupportedInterfaceOrientations: []
         NSAppTransportSecurity: true
         UILaunchStoryboardName: LaunchScreen


### PR DESCRIPTION
### Descrição simples da nova feature
 
adicionado testes para o metodo formattedAccount
configurado o project.yml:
- para rodar no mac com m1
- versão 15.2 do swift
- desabilitado pod por enquanto, ja que não estamos usando
 
### Checklist:
Coloque um ```x``` nas caixas que se aplicam.
- [x] Não adiciona código duplicado
- [x] Não contém código comentado
- [x] Não contém código WIP
 
### Evidências da feature:
| iPhone SE | iPhone 12 Max |
| ------ | ------ |
| print  | print |
