### PR TITLE
✨ - create tests to ActivityDetailsViewModel

### DIFF
--- a/solutions/devsprint-caio-santos-5/FinanceApp/Helper/DispatchQueueProtocol.swift
+++ b/solutions/devsprint-caio-santos-5/FinanceApp/Helper/DispatchQueueProtocol.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+protocol DispatchQueueProtocol {
+    func async(group: DispatchGroup?, qos: DispatchQoS, flags: DispatchWorkItemFlags, execute work: @escaping () -> Void)
+}
+
+extension DispatchQueueProtocol {
+    func async(group: DispatchGroup? = nil, qos: DispatchQoS = .unspecified, flags: DispatchWorkItemFlags = [], execute work: @escaping () -> Void) {
+        self.async(group: group, qos: qos, flags: flags, execute: work)
+    }
+}
+
+extension DispatchQueue: DispatchQueueProtocol {}

--- a/solutions/devsprint-caio-santos-5/FinanceApp/Modules/ActivityDetails/ActivityDetailsViewModel.swift
+++ b/solutions/devsprint-caio-santos-5/FinanceApp/Modules/ActivityDetails/ActivityDetailsViewModel.swift
@@ -1,37 +1,23 @@
-//
-//  ActivityDetailsViewModel.swift
-//  FinanceApp
-//
-//  Created by Rodrigo Borges on 03/03/22.
-//
-
 import Foundation
 
 protocol ActivityDetailsViewModelDelegate: AnyObject {
-
     func didFetchActivityDetails(_ data: ActivityDetails)
 }
 
 struct ActivityDetailsViewModel {
-
     weak var delegate: ActivityDetailsViewModelDelegate?
-
     private let financeService: FinanceServiceProtocol
-
-    init(financeService: FinanceServiceProtocol) {
+    private let queue: DispatchQueueProtocol
+    
+    init(financeService: FinanceServiceProtocol, queue: DispatchQueueProtocol) {
         self.financeService = financeService
+        self.queue = queue
     }
-
+    
     func fetchData() {
-
         financeService.fetchActivityDetails { activityDetails in
-
-            guard let activityDetails = activityDetails else {
-                return
-            }
-
-            DispatchQueue.main.async {
-
+            guard let activityDetails = activityDetails else { return }
+            queue.async {
                 delegate?.didFetchActivityDetails(activityDetails)
             }
         }

--- a/solutions/devsprint-caio-santos-5/FinanceAppTests/Helper/DispatchQueueMock.swift
+++ b/solutions/devsprint-caio-santos-5/FinanceAppTests/Helper/DispatchQueueMock.swift
@@ -1,0 +1,13 @@
+@testable import FinanceApp
+import Foundation
+import XCTest
+
+final class DispatchQueueMock: DispatchQueueProtocol {
+    var asyncImpl: (_ group: DispatchGroup?, _ qos: DispatchQoS, _ flags: DispatchWorkItemFlags, _ work: @escaping () -> Void) -> Void = { _, _, _, _  in
+        XCTFail("asyncImpl not implemented")
+    }
+    
+    func async(group: DispatchGroup?, qos: DispatchQoS, flags: DispatchWorkItemFlags, execute work: @escaping () -> Void) {
+        asyncImpl(group, qos, flags, work)
+    }
+}

--- a/solutions/devsprint-caio-santos-5/FinanceAppTests/Modules/ActivityDetails/ActivityDetailsViewModelDelegateMock.swift
+++ b/solutions/devsprint-caio-santos-5/FinanceAppTests/Modules/ActivityDetails/ActivityDetailsViewModelDelegateMock.swift
@@ -1,0 +1,12 @@
+@testable import FinanceApp
+import XCTest
+
+final class ActivityDetailsViewModelDelegateMock: ActivityDetailsViewModelDelegate {
+    var didFetchActivityDetailsImpl: (_ data: ActivityDetails) -> Void = { _ in
+        XCTFail("didFetchActivityDetailsImpl not implemented")
+    }
+    
+    func didFetchActivityDetails(_ data: ActivityDetails) {
+        didFetchActivityDetailsImpl(data)
+    }
+}

--- a/solutions/devsprint-caio-santos-5/FinanceAppTests/Modules/ActivityDetails/ActivityDetailsViewModelTests.swift
+++ b/solutions/devsprint-caio-santos-5/FinanceAppTests/Modules/ActivityDetails/ActivityDetailsViewModelTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+@testable import FinanceApp
+import XCTest
+
+final class ActivityDetailsViewModelTests: XCTestCase {
+    typealias Sut = ActivityDetailsViewModel
+    
+    func test_Sut_ShouldNotKeepStrongReferenceToDelegate() {
+        let (sut, fields) = makeSut()
+        
+        fields.delegate = nil
+        
+        XCTAssertNil(sut.delegate)
+    }
+    
+    func test_FetchData_WhenServiceSuccess_ShouldPassDataToDelegate_OnMainThread() {
+        var financeServiceCompletion: ((ActivityDetails?) -> Void)?
+        var queueCompletion: (() -> Void)?
+        defer {
+            financeServiceCompletion = nil
+            queueCompletion = nil
+        }
+        let (sut, fields) = makeSut()
+        fields.financeService.fetchActivityDetailsImpl = { [unowned fields] in
+            fields.callOrder.append("fetchActivityDetails called")
+            financeServiceCompletion = $0
+        }
+        fields.queue.asyncImpl = { [unowned fields] in
+            fields.callOrder.append("queue called")
+            queueCompletion = $3
+        }
+        fields.delegate?.didFetchActivityDetailsImpl = { [unowned fields] activityDetails in
+            fields.callOrder.append("didFetchActivityDetails called")
+            XCTAssertEqual(activityDetails, .fixture())
+        }
+        
+        sut.fetchData()
+        
+        XCTAssertEqual(fields.callOrder, ["fetchActivityDetails called"])
+        
+        financeServiceCompletion?(.fixture())
+        
+        XCTAssertEqual(fields.callOrder, ["fetchActivityDetails called", "queue called"])
+        
+        queueCompletion?()
+        
+        XCTAssertEqual(fields.callOrder, [
+            "fetchActivityDetails called",
+            "queue called",
+            "didFetchActivityDetails called"
+        ])
+    }
+    
+    func test_FetchData_WhenServiceFail_ShouldDoNothing() {
+        let (sut, fields) = makeSut()
+        fields.financeService.fetchActivityDetailsImpl = { [unowned fields] completion in
+            fields.callOrder.append("fetchActivityDetails called")
+            completion(nil)
+        }
+        
+        sut.fetchData()
+        
+        XCTAssertEqual(fields.callOrder, ["fetchActivityDetails called"])
+    }
+}
+
+extension ActivityDetailsViewModelTests {
+    final class Fields {
+        var callOrder = [String]()
+        let financeService = FinanceServiceMock()
+        let queue = DispatchQueueMock()
+        var delegate: ActivityDetailsViewModelDelegateMock? = .init()
+    }
+    
+    func makeSut() -> (sut: Sut, fields: Fields) {
+        let fields = Fields()
+        
+        var sut  = Sut(financeService: fields.financeService, queue: fields.queue)
+        sut.delegate = fields.delegate
+        
+        addTeardownBlock { [weak delegate = fields.delegate, weak queue = fields.queue, weak financeService = fields.financeService] in
+            XCTAssertNil(delegate)
+            XCTAssertNil(queue)
+            XCTAssertNil(financeService)
+        }
+        return (sut, fields)
+    }
+}

--- a/solutions/devsprint-caio-santos-5/FinanceAppTests/Service/FinanceServiceMock.swift
+++ b/solutions/devsprint-caio-santos-5/FinanceAppTests/Service/FinanceServiceMock.swift
@@ -1,0 +1,41 @@
+import Foundation
+@testable import FinanceApp
+import XCTest
+
+final class FinanceServiceMock: FinanceServiceProtocol {
+    var fetchHomeDataImpl: (_ completion: @escaping (HomeData?) -> Void) -> Void = { _ in
+        XCTFail("fetchHomeDataImpl not implemented")
+    }
+    var fetchActivityDetailsImpl: (_ completion: @escaping (ActivityDetails?) -> Void) -> Void = { _ in
+        XCTFail("fetchActivityDetailsImpl not implemented")
+    }
+    var fetchContactListImpl: (_ completion: @escaping ([Contact]?) -> Void) -> Void = { _ in
+        XCTFail("fetchContactListImpl not implemented")
+    }
+    var transferAmountImpl: (_ completion: @escaping (TransferResult?) -> Void) -> Void = { _ in
+        XCTFail("transferAmountImpl not implemented")
+    }
+    var fetchUserProfileImpl: (_ completion: @escaping (UserProfile?) -> Void) -> Void = { _ in
+        XCTFail("fetchUserProfileImpl not implemented")
+    }
+    
+    func fetchHomeData(_ completion: @escaping (HomeData?) -> Void) {
+        fetchHomeDataImpl(completion)
+    }
+    
+    func fetchActivityDetails(_ completion: @escaping (ActivityDetails?) -> Void) {
+        fetchActivityDetailsImpl(completion)
+    }
+    
+    func fetchContactList(_ completion: @escaping ([Contact]?) -> Void) {
+        fetchContactListImpl(completion)
+    }
+    
+    func transferAmount(_ completion: @escaping (TransferResult?) -> Void) {
+        transferAmountImpl(completion)
+    }
+    
+    func fetchUserProfile(_ completion: @escaping (UserProfile?) -> Void) {
+        fetchUserProfileImpl(completion)
+    }
+}


### PR DESCRIPTION
### Descrição simples da nova feature
 
criado DispatchQueueProtocol para abstrair DispatchQueue
criado mock também
criada fixture para ActivityDetails
criado mock para ActivityDetailsViewModelDelegate e FinanceServiceProtocol
criados testes para ActivityDetailsViewModel
 
### Checklist:
Coloque um ```x``` nas caixas que se aplicam.
- [x] Não adiciona código duplicado
- [x] Não contém código comentado
- [x] Não contém código WIP
 
### Evidências da feature:
| iPhone SE | iPhone 12 Max |
| ------ | ------ |
| print  | print |
