### PR TITLE
add: inside navigation controller tests

### DIFF
--- a/solutions/devsprint-leonardo-santos-3/FinanceAppTests/Extensions/UIViewControllerExtensionsTests.swift
+++ b/solutions/devsprint-leonardo-santos-3/FinanceAppTests/Extensions/UIViewControllerExtensionsTests.swift
@@ -2,15 +2,12 @@ import XCTest
 
 @testable import FinanceApp
 
-
-final class UIViewControllerExtensionsTests:XCTestCase {
+final class UIViewControllerExtensionsTests: XCTestCase {
     private let sut = UIViewController()
-    
     
     func test_insideNavigationController_shouldReturnNavigationController(){
         
         let navigationController =  sut.insideNavigationController()
-        
         
         XCTAssertNotNil(navigationController)
         XCTAssertEqual(navigationController.topViewController, sut)

--- a/solutions/devsprint-leonardo-santos-3/FinanceAppTests/Extensions/UIViewControllerExtensionsTests.swift
+++ b/solutions/devsprint-leonardo-santos-3/FinanceAppTests/Extensions/UIViewControllerExtensionsTests.swift
@@ -1,1 +1,20 @@
+import XCTest
 
+@testable import FinanceApp
+
+
+final class UIViewControllerExtensionsTests:XCTestCase {
+    private let sut = UIViewController()
+    
+    
+    func test_insideNavigationController_shouldReturnNavigationController(){
+        
+        let navigationController =  sut.insideNavigationController()
+        
+        
+        XCTAssertNotNil(navigationController)
+        XCTAssertEqual(navigationController.topViewController, sut)
+        XCTAssertEqual(navigationController.modalPresentationStyle, .formSheet)
+        
+    }
+}


### PR DESCRIPTION
### Descrição simples da nova feature
 Implements UIViewControllerExtensionsTests;

Tests implemented:
test_insideNavigationController_shouldReturnNavigationController()
 
### Checklist:
Coloque um ```x``` nas caixas que se aplicam.
- [x] Não adiciona código duplicado
- [x] Não contém código comentado
- [x] Não contém código WIP
 
### Evidências da feature:
<img width="532" alt="Screen Shot 2022-09-20 at 10 55 11 AM" src="https://user-images.githubusercontent.com/53008706/191276879-2453f476-3361-45d5-b7ce-7d115669f3ac.png"> 
